### PR TITLE
Add a simple composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "rtcamp/gravityforms-sfmc-data-extension",
+  "description": "Gravity Forms to SFMC Data Extension Add-On",
+  "type": "wordpress-plugin",
+  "license": "GPLv2",
+  "authors": [
+    {
+      "name": "rtCamp",
+      "homepage": "https://rtcamp.com/"
+    }
+  ],
+  "support": {
+    "source": "https://github.com/rtCamp/gravityforms-sfmc-data-extension"
+  }
+}


### PR DESCRIPTION
This would help installing the plugin in use cases where composer is being used as a package manager.