### PR TITLE
Fix logic for data-processing of the feed

### DIFF
--- a/includes/class-gravityforms-sfmc-data-extension-addon.php
+++ b/includes/class-gravityforms-sfmc-data-extension-addon.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * File to include Registration addon functionality.
- * 
+ *
  * @package gravityforms-sfmc-data-extension.
  */
 
@@ -22,42 +22,42 @@ class Gravityforms_SFMC_Data_Extension_Addon extends GFFeedAddOn {
 	/**
 	 * Slug of addon.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_slug = 'gravityforms-sfmc-data-extension';
 
 	/**
 	 * Path to main file.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_path = 'gravityforms-sfmc-data-extension/gravityforms-sfmc-data-extension-addon.php';
 
 	/**
 	 * Full Path.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_full_path = __FILE__;
 
 	/**
 	 * Title of the form.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_title = 'Gravity Forms to SFMC Data Extension Add-On';
 
 	/**
 	 * Short title.
-	 * 
-	 * @var string 
+	 *
+	 * @var string
 	 */
 	protected $_short_title = 'Gravity Forms to SFMC Data Extension';
 
 	/**
 	 * Instance object.
 	 *
-	 * @var null 
+	 * @var null
 	 */
 	private static $_instance = null;
 
@@ -203,11 +203,15 @@ class Gravityforms_SFMC_Data_Extension_Addon extends GFFeedAddOn {
 
 			foreach ( $sfmc_fields as $sfmc_field ) {
 
-				if ( 'ContactKey' === $sfmc_field || 'SubscriberKey' === $sfmc_field || 'EmailAddress' === $sfmc_field ) {
+				if ( 'ContactKey' === $sfmc_field ) {
 					$sfmc_data['ContactKey']            = $entry_field_value;
-					$sfmc_data['Data']['SubscriberKey'] = $entry_field_value;
 					$sfmc_data['Data']['ContactKey']    = $entry_field_value;
+				} else if ( 'SubscriberKey' === $sfmc_field ) {
+					$sfmc_data['Data']['SubscriberKey'] = $entry_field_value;
+				} else if(  'EmailAddress' === $sfmc_field ) {
 					$sfmc_data['Data']['EmailAddress']  = $entry_field_value;
+				} elseif ( 'EventDefinitionKey' === $sfmc_field ) {
+					$sfmc_data['EventDefinitionKey'] = $entry_field_value;
 				} elseif ( 'EventDefinitionKey' === $sfmc_field ) {
 					$sfmc_data['EventDefinitionKey'] = $entry_field_value;
 				} else {


### PR DESCRIPTION
When processing the fields, before sending it to MarketingCloud the OR-logic is not correct and overwrites its own `$sfmc_data` array. This PR fixes this in splitting it to multiple if-statements.

Fixes #6 