### PR TITLE
[master] Fix: PHPCS Fixes and Update tested upto version

### DIFF
--- a/gravityforms-sfmc-data-extension.php
+++ b/gravityforms-sfmc-data-extension.php
@@ -4,7 +4,7 @@
  * Description: Submit the Gravityform entries to Salesforce Marketing Cloud Using Journey Entry Event.
  * Version: 1.0
  * Requires at least: 5.5
- * Tested up to: 5.5
+ * Tested up to: 6.7.2
  * Author URI: https://rtcamp.com
  * Plugin URI: https://rtcamp.com
  * Author: rtCamp, kiranpotphode
@@ -29,15 +29,14 @@ class Gravityforms_SFMC_Data_Extension_Bootstrap {
 			return;
 		}
 
-		require_once( plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-addon.php' );
-		require_once( plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-auth.php' );
-		require_once( plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-upsert.php' );
-		require_once( plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-notify-error.php' );
-		require_once( plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-email.php' );
+		require_once plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-addon.php';
+		require_once plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-auth.php';
+		require_once plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-upsert.php';
+		require_once plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-notify-error.php';
+		require_once plugin_dir_path( __FILE__ ) . '/includes/class-gravityforms-sfmc-data-extension-email.php';
 
 		GFAddOn::register( 'Gravityforms_SFMC_Data_Extension_Addon' );
 	}
-
 }
 
 add_action( 'gform_loaded', array( 'Gravityforms_SFMC_Data_Extension_Bootstrap', 'load' ), 5 );

--- a/includes/class-gravityforms-sfmc-data-extension-addon.php
+++ b/includes/class-gravityforms-sfmc-data-extension-addon.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * File to include Registration addon functionality.
- * 
+ *
  * @package gravityforms-sfmc-data-extension.
  */
 
@@ -22,42 +22,42 @@ class Gravityforms_SFMC_Data_Extension_Addon extends GFFeedAddOn {
 	/**
 	 * Slug of addon.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_slug = 'gravityforms-sfmc-data-extension';
 
 	/**
 	 * Path to main file.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_path = 'gravityforms-sfmc-data-extension/gravityforms-sfmc-data-extension-addon.php';
 
 	/**
 	 * Full Path.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_full_path = __FILE__;
 
 	/**
 	 * Title of the form.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $_title = 'Gravity Forms to SFMC Data Extension Add-On';
 
 	/**
 	 * Short title.
-	 * 
-	 * @var string 
+	 *
+	 * @var string
 	 */
 	protected $_short_title = 'Gravity Forms to SFMC Data Extension';
 
 	/**
 	 * Instance object.
 	 *
-	 * @var null 
+	 * @var null
 	 */
 	private static $_instance = null;
 
@@ -200,7 +200,6 @@ class Gravityforms_SFMC_Data_Extension_Addon extends GFFeedAddOn {
 			$sfmc_fields       = array_map( 'trim', explode( ',', $field->sfmc_field_key ) );
 			$entry_field_value = $this->get_field_value( $form, $entry, $field->id );
 
-
 			foreach ( $sfmc_fields as $sfmc_field ) {
 
 				if ( 'ContactKey' === $sfmc_field || 'SubscriberKey' === $sfmc_field || 'EmailAddress' === $sfmc_field ) {
@@ -210,18 +209,16 @@ class Gravityforms_SFMC_Data_Extension_Addon extends GFFeedAddOn {
 					$sfmc_data['Data']['EmailAddress']  = $entry_field_value;
 				} elseif ( 'EventDefinitionKey' === $sfmc_field ) {
 					$sfmc_data['EventDefinitionKey'] = $entry_field_value;
-				} else {
-					if ( isset( $sfmc_data['Data'][ $sfmc_field ] ) ) {
-						if ( strlen( $entry_field_value ) ) {
-							if ( strlen( $sfmc_data['Data'][ $sfmc_field ] ) ) {
-								$sfmc_data['Data'][ $sfmc_field ] .= ', ' . $entry_field_value;
-							} else {
-								$sfmc_data['Data'][ $sfmc_field ] .= $entry_field_value;
-							}
+				} elseif ( isset( $sfmc_data['Data'][ $sfmc_field ] ) ) {
+					if ( strlen( $entry_field_value ) ) {
+						if ( strlen( $sfmc_data['Data'][ $sfmc_field ] ) ) {
+							$sfmc_data['Data'][ $sfmc_field ] .= ', ' . $entry_field_value;
+						} else {
+							$sfmc_data['Data'][ $sfmc_field ] .= $entry_field_value;
 						}
-					} else {
-						$sfmc_data['Data'][ $sfmc_field ] = $entry_field_value;
 					}
+				} else {
+					$sfmc_data['Data'][ $sfmc_field ] = $entry_field_value;
 				}
 			}
 		}

--- a/includes/class-gravityforms-sfmc-data-extension-auth.php
+++ b/includes/class-gravityforms-sfmc-data-extension-auth.php
@@ -44,30 +44,29 @@ class Gravityforms_SFMC_Data_Extension_Auth {
 		$account_id    = ( is_array( $creds ) && $creds['account_id'] ) ? $creds['account_id'] : '';
 		$external_key  = ( is_array( $creds ) && $creds['external_key'] ) ? $creds['external_key'] : '';
 
-
 		if ( empty( $client_secret ) || empty( $client_id ) || empty( $account_id ) ) {
 			return false;
 		}
 
-		$body = [
+		$body = array(
 			'grant_type'    => 'client_credentials',
 			'client_id'     => $client_id,
 			'client_secret' => $client_secret,
 			'account_id'    => $account_id,
-		];
+		);
 
 		$response = wp_safe_remote_post(
 			esc_url( 'https://' . $external_key . '.auth.marketingcloudapis.com/v2/token' ),
-			[
+			array(
 				'method'      => 'POST',
 				'httpversion' => '1.1',
 				'redirection' => 10,
 				'timeout'     => 50,
-				'headers'     => [
+				'headers'     => array(
 					'Content-Type' => 'application/json',
-				],
+				),
 				'body'        => wp_json_encode( $body ),
-			]
+			)
 		);
 
 		if ( is_wp_error( $response ) || 200 !== $response['response']['code'] ) {

--- a/includes/class-gravityforms-sfmc-data-extension-notify-error.php
+++ b/includes/class-gravityforms-sfmc-data-extension-notify-error.php
@@ -19,10 +19,10 @@ class Gravityforms_SFMC_Data_Extension_Notify_Error {
 	 * @param string $error_message Error message.
 	 * @param array  $recipients List of recipients.
 	 */
-	static public function send_error_email( $post_url, $status_code, $error_message, $recipients ) {
+	public static function send_error_email( $post_url, $status_code, $error_message, $recipients ) {
 		if ( $post_url ) {
 			$subject = 'Alert: Salesforce API failure for ' . get_bloginfo( 'name' );
-			$message = Gravityforms_SFMC_Data_Extension_Notify_Error::get_error_email_template( $post_url, $status_code, $error_message );
+			$message = self::get_error_email_template( $post_url, $status_code, $error_message );
 
 			// Set mail type to text/html.
 			add_filter( 'wp_mail_content_type', array( 'Gravityforms_SFMC_Data_Extension_Notify_Error', 'set_html_email' ) );
@@ -41,7 +41,7 @@ class Gravityforms_SFMC_Data_Extension_Notify_Error {
 	 *
 	 * @return string Email format.
 	 */
-	static public function set_html_email() {
+	public static function set_html_email() {
 		return 'text/html';
 	}
 
@@ -54,7 +54,7 @@ class Gravityforms_SFMC_Data_Extension_Notify_Error {
 	 *
 	 * @return string Email template.
 	 */
-	static public function get_error_email_template( $post_url, $status_code, $error_message ) {
+	public static function get_error_email_template( $post_url, $status_code, $error_message ) {
 		$date = gmdate( 'F j, Y H:i:s' );
 
 		// =====

--- a/includes/class-gravityforms-sfmc-data-extension-upsert.php
+++ b/includes/class-gravityforms-sfmc-data-extension-upsert.php
@@ -54,8 +54,6 @@ class Gravityforms_SFMC_Data_Extension_Upsert {
 		$data['Data']['Submission_Date'] = gmdate( 'n/j/Y G:i:s' );
 		$data                            = wp_json_encode( $this->validate_lengths( $data ) );
 
-
-
 		// Send data to SF data extention.
 		$response = wp_safe_remote_post(
 			esc_url( 'https://' . $external_key . '.rest.marketingcloudapis.com/interaction/v1/events' ),


### PR DESCRIPTION
I have tested the plugin locally in the following environment:

## Testing Environment

- WordPress Version: **`6.7.2`**
- PHP Version: **`8.3.11`**
- MySQL Version: **`8.0.35`**
- Web Server: **`Nginx`**
- Mac OS Version: **`15.3.1`**
- Chrome Version: **`134.0.6998.45`**

## Observations

- No PHP compatibility issues were found on PHP 8+. 

- The plugin runs smoothly on WordPress 6.7.2 without any fatal errors or warnings.

## Notes

Due to the unavailability of **Salesforce Marketing Cloud (SFMC) credentials**, I was unable to test data submission directly. However, I added debugging points and logs to verify that entries are being processed correctly and JSON-encoded before reaching the REST API endpoint.

Additionally, I have fixed several PHPCS issues identified during testing.

## Issue

#8 