### PR TITLE
Run Copilot code review on GitHub-hosted runners

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,22 @@
+name: Copilot code review setup steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  # The job must be named `copilot-setup-steps`, or Copilot ignores this file.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Start Review
+        run: echo "Starting Review."


### PR DESCRIPTION
This repository is public, so Copilot code review cannot use rtCamp self-hosted Actions Runner Controller scale sets, which are not exposed to public repositories.

Adds `.github/workflows/copilot-code-review.yml`, which pins Copilot code review to `ubuntu-latest`. The file takes precedence over `copilot-setup-steps.yml` and over the organization-level runner type for Copilot code review only; Copilot cloud agent keeps using the organization configuration.

No dependencies are installed: Copilot clones the repository and provisions what it needs itself. Repository-specific setup steps can be added to this file later if a review needs extra tooling.

Docs: https://docs.github.com/en/copilot/how-tos/copilot-on-github/set-up-copilot/configure-runners